### PR TITLE
Install ansible-core from pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/ansible/ansible.git@devel#egg=ansible-core
+ansible-core


### PR DESCRIPTION
Now that we have an official upload (beta) we can use pypi over git.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>