### PR TITLE
Remove python bindings for libselinux / rpm

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -11,7 +11,5 @@ python38-pycparser [platform:centos-8 platform:rhel-8]
 python38-pyparsing [platform:centos-8]
 python38-six [platform:centos-8 platform:rhel-8]
 python38-yaml [platform:centos-8 platform:rhel-8]
-python3-rpm
-libselinux-python3
 rsync
 sshpass [epel]


### PR DESCRIPTION
Latest version of ansible-core no longer requires these python bindings,
so lets drop them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>